### PR TITLE
37 fix 검색 기록에 출발장소 도착장소의 이름 추가

### DIFF
--- a/src/main/java/com/restspotfinder/apicount/domain/PlaceSearchCount.java
+++ b/src/main/java/com/restspotfinder/apicount/domain/PlaceSearchCount.java
@@ -2,10 +2,7 @@ package com.restspotfinder.apicount.domain;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDate;
 
@@ -13,6 +10,7 @@ import java.time.LocalDate;
 @Getter
 @Entity
 @Builder
+@ToString
 @NoArgsConstructor
 @AllArgsConstructor
 public class PlaceSearchCount {

--- a/src/main/java/com/restspotfinder/apicount/repository/PlaceSearchCountRepository.java
+++ b/src/main/java/com/restspotfinder/apicount/repository/PlaceSearchCountRepository.java
@@ -7,9 +7,10 @@ import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 public interface PlaceSearchCountRepository extends JpaRepository<PlaceSearchCount, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT c FROM PlaceSearchCount c WHERE c.createdAt = :today")
-    PlaceSearchCount findByDateWithPessimisticLock(LocalDate today);
+    Optional<PlaceSearchCount> findByDateWithPessimisticLock(LocalDate today);
 }

--- a/src/main/java/com/restspotfinder/apicount/repository/RouteSearchCountRepository.java
+++ b/src/main/java/com/restspotfinder/apicount/repository/RouteSearchCountRepository.java
@@ -7,9 +7,10 @@ import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 public interface RouteSearchCountRepository extends JpaRepository<RouteSearchCount, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT c FROM RouteSearchCount c WHERE c.createdAt = :startOfMonth")
-    RouteSearchCount findByDateWithPessimisticLock(LocalDate startOfMonth);
+    Optional<RouteSearchCount> findByDateWithPessimisticLock(LocalDate startOfMonth);
 }

--- a/src/main/java/com/restspotfinder/apicount/service/CountService.java
+++ b/src/main/java/com/restspotfinder/apicount/service/CountService.java
@@ -18,7 +18,8 @@ public class CountService {
 
     @Transactional
     public int increasePlaceSearchCount(LocalDate today) {
-        PlaceSearchCount placeSearchCount = placeSearchCountRepository.findByDateWithPessimisticLock(today);
+        PlaceSearchCount placeSearchCount = placeSearchCountRepository.findByDateWithPessimisticLock(today)
+                .orElse(PlaceSearchCount.init(LocalDate.now()));
         int count = placeSearchCount.increase();
 
         placeSearchCountRepository.save(placeSearchCount);

--- a/src/main/java/com/restspotfinder/apicount/service/CountService.java
+++ b/src/main/java/com/restspotfinder/apicount/service/CountService.java
@@ -29,8 +29,8 @@ public class CountService {
     @Transactional
     public int increaseRouteSearchCount(LocalDate today) {
         LocalDate startOfMonth = today.withDayOfMonth(1);
-        System.out.println("startOfMonth = " + startOfMonth);
-        RouteSearchCount routeSearchCount = routeSearchCountRepository.findByDateWithPessimisticLock(startOfMonth);
+        RouteSearchCount routeSearchCount = routeSearchCountRepository.findByDateWithPessimisticLock(startOfMonth)
+                .orElse(RouteSearchCount.init(startOfMonth));
         int count = routeSearchCount.increase();
 
         routeSearchCountRepository.save(routeSearchCount);

--- a/src/main/java/com/restspotfinder/route/controller/request/RouteRequestDTO.java
+++ b/src/main/java/com/restspotfinder/route/controller/request/RouteRequestDTO.java
@@ -1,0 +1,26 @@
+package com.restspotfinder.route.controller.request;
+
+import com.restspotfinder.route.domain.RouteOption;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+public class RouteRequestDTO {
+    private String start;
+    private String startName;
+    private String goal;
+    private String goalName;
+    private int page = 1; // 기본값 설정
+    private String waypoints;
+
+    public String getDirect5RequestUrl(String direct5Url) {
+        return direct5Url + "?start=" + start + "&goal=" + goal + "&waypoints=" + waypoints + "&option=" + RouteOption.getOptionValues(page);
+    }
+
+    public boolean isWaypointsEmpty(){
+        return waypoints == null || waypoints.isBlank();
+    }
+}

--- a/src/main/java/com/restspotfinder/route/domain/Route.java
+++ b/src/main/java/com/restspotfinder/route/domain/Route.java
@@ -1,5 +1,6 @@
 package com.restspotfinder.route.domain;
 
+import com.restspotfinder.route.controller.request.RouteRequestDTO;
 import jakarta.persistence.*;
 import lombok.*;
 import org.locationtech.jts.geom.Coordinate;
@@ -33,13 +34,15 @@ public class Route {
 
     private Point start; // 출발지
     private Point goal; // 목적지
+    private String startName; // 출발지 명
+    private String goalName; // 목적지 명
     private Point waypoint1; // 경유지 1
     private Point waypoint2; // 경유지 2
     private Point waypoint3; // 경유지 3
     private Point waypoint4; // 경유지 4
     private Point waypoint5; // 경유지 5
 
-    public static Route from(NaverRoute naverRoute, long searchId, String start, String goal, String waypoints) {
+    public static Route from(NaverRoute naverRoute, long searchId, RouteRequestDTO routeRequestDTO) {
         Route.RouteBuilder builder = Route.builder()
                 .searchId(searchId)
                 .distance(naverRoute.getDistance())
@@ -49,13 +52,15 @@ public class Route {
                 .lineString(new GeometryFactory().createLineString(naverRoute.getPath()))
                 .routeOption(naverRoute.getOption())
                 .createdDate(LocalDateTime.now())
-                .start(convertStringToPoint(start))
-                .goal(convertStringToPoint(goal));
+                .start(convertStringToPoint(routeRequestDTO.getStart()))
+                .startName(routeRequestDTO.getStartName())
+                .goal(convertStringToPoint(routeRequestDTO.getGoal()))
+                .goalName(routeRequestDTO.getGoalName());
 
-        if (waypoints == null || waypoints.isBlank())
+        if (routeRequestDTO.isWaypointsEmpty())
             return builder.build();
 
-        String[] waypointArr = waypoints.split("\\|");
+        String[] waypointArr = routeRequestDTO.getWaypoints().split("\\|");
         for (int i = 0; i < waypointArr.length; i++) {
             Point waypoint = convertStringToPoint(waypointArr[i]);
             switch (i) {
@@ -69,8 +74,8 @@ public class Route {
 
         return builder.build();
     }
-    public static List<Route> fromList(List<NaverRoute> naverRouteList, long searchId, String start, String goal, String waypoints) {
-        return naverRouteList.stream().map(naverRoute -> Route.from(naverRoute, searchId, start, goal, waypoints)).toList();
+    public static List<Route> fromList(List<NaverRoute> naverRouteList, long searchId, RouteRequestDTO routeRequestDTO) {
+        return naverRouteList.stream().map(naverRoute -> Route.from(naverRoute, searchId, routeRequestDTO)).toList();
     }
 
     public static Point convertStringToPoint(String location) {

--- a/src/main/java/com/restspotfinder/route/service/NaverRouteService.java
+++ b/src/main/java/com/restspotfinder/route/service/NaverRouteService.java
@@ -2,6 +2,7 @@ package com.restspotfinder.route.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.restspotfinder.route.controller.request.RouteRequestDTO;
 import com.restspotfinder.route.domain.NaverRoute;
 import com.restspotfinder.route.domain.RouteOption;
 import lombok.RequiredArgsConstructor;
@@ -29,9 +30,12 @@ public class NaverRouteService {
     @Value("${naver.cloud-platform.client-secret}")
     String CLIENT_SECRET;
 
-    public List<NaverRoute> getRouteData(String start, String goal, String waypoints, int page) {
-        String requestURL = DIRECT5_URL + "?start=" + start + "&goal=" + goal + "&waypoints=" + waypoints + "&option=" + RouteOption.getOptionValues(page);
-        return NaverRoute.fromList(connect(requestURL), RouteOption.getOptionList(page));
+    public List<NaverRoute> getRouteData(RouteRequestDTO routeRequestDTO) {
+        List<RouteOption> routeOption = RouteOption.getOptionList(routeRequestDTO.getPage());
+        String requestURL = routeRequestDTO.getDirect5RequestUrl(DIRECT5_URL);
+        JsonNode resultNode = connect(requestURL);
+
+        return NaverRoute.fromList(resultNode, routeOption);
     }
 
     public JsonNode connect(String requestURL) {

--- a/src/main/java/com/restspotfinder/route/service/RouteService.java
+++ b/src/main/java/com/restspotfinder/route/service/RouteService.java
@@ -1,5 +1,6 @@
 package com.restspotfinder.route.service;
 
+import com.restspotfinder.route.controller.request.RouteRequestDTO;
 import com.restspotfinder.route.domain.NaverRoute;
 import com.restspotfinder.route.domain.Route;
 import com.restspotfinder.route.repository.RouteRepository;
@@ -15,8 +16,8 @@ public class RouteService {
     private final RouteRepository routeRepository;
 
     @Transactional
-    public List<Route> create(List<NaverRoute> naverRouteList, long searchId, String start, String goal, String waypoints) {
-        return routeRepository.saveAll(Route.fromList(naverRouteList, searchId, start, goal, waypoints));
+    public List<Route> create(List<NaverRoute> naverRouteList, long searchId, RouteRequestDTO routeRequestDTO) {
+        return routeRepository.saveAll(Route.fromList(naverRouteList, searchId, routeRequestDTO));
     }
 
     @Transactional

--- a/src/main/java/com/restspotfinder/search/domain/Search.java
+++ b/src/main/java/com/restspotfinder/search/domain/Search.java
@@ -1,5 +1,6 @@
 package com.restspotfinder.search.domain;
 
+import com.restspotfinder.route.controller.request.RouteRequestDTO;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -20,11 +21,22 @@ public class Search {
     private long searchId;
     @Enumerated(EnumType.STRING)
     private SearchType type; // ex) recent, route
+    private String startName;
+    private String goalName;
     private LocalDateTime createdAt;
 
-    public static Search from(SearchType searchType){
+    public static Search fromRoute(RouteRequestDTO routeRequestDTO){
         return Search.builder()
-                .type(searchType)
+                .type(SearchType.route)
+                .startName(routeRequestDTO.getStartName())
+                .goalName(routeRequestDTO.getGoalName())
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    public static Search fromSearch(){
+        return Search.builder()
+                .type(SearchType.recent)
                 .createdAt(LocalDateTime.now())
                 .build();
     }

--- a/src/main/java/com/restspotfinder/search/repository/SearchRepository.java
+++ b/src/main/java/com/restspotfinder/search/repository/SearchRepository.java
@@ -2,14 +2,7 @@ package com.restspotfinder.search.repository;
 
 import com.restspotfinder.search.domain.Search;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
-import java.time.LocalDate;
 
 public interface SearchRepository extends JpaRepository<Search, Long> {
-    @Query("SELECT COUNT(s) FROM Search s WHERE DATE(s.createdAt) = :specificDate AND s.type = 'place'")
-    int countForPlace(LocalDate specificDate);
-
-    @Query("SELECT COUNT(s) FROM Search s WHERE DATE(s.createdAt) BETWEEN :startOfMonth AND :endOfMonth AND s.type = 'route'")
-    int countForRouteInMonth(LocalDate startOfMonth, LocalDate endOfMonth);
 }

--- a/src/main/java/com/restspotfinder/search/service/SearchService.java
+++ b/src/main/java/com/restspotfinder/search/service/SearchService.java
@@ -1,7 +1,7 @@
 package com.restspotfinder.search.service;
 
+import com.restspotfinder.route.controller.request.RouteRequestDTO;
 import com.restspotfinder.search.domain.Search;
-import com.restspotfinder.search.domain.SearchType;
 import com.restspotfinder.search.repository.SearchRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -11,7 +11,13 @@ import org.springframework.stereotype.Service;
 public class SearchService {
     private final SearchRepository searchRepository;
 
-    public Search create(SearchType searchType) {
-        return searchRepository.save(Search.from(searchType));
+    public Search createByRoute(RouteRequestDTO routeRequestDTO) {
+        Search search = Search.fromRoute(routeRequestDTO);
+        return searchRepository.save(search);
+    }
+
+    public void createByRecent() {
+        Search search = Search.fromSearch();
+        searchRepository.save(search);
     }
 }


### PR DESCRIPTION
## 💡 개요 (필수)

- Search 엔티티로 사용자가 얼마나 검색했는지, 어디를 검색했는지 파악하는데, 출발지, 도착지가 위도,경도로만 표시되어 어느지역을 많이 검색하는지 알기가 어려움.

## 📃 작업내용 (필수)

- Client에서 출발지명, 도착지명 입력받아 Search Entity에 추가