### PR TITLE
feat: 주유소 정보 업데이트 API

### DIFF
--- a/src/main/java/com/restspotfinder/RestSpotFinderApplication.java
+++ b/src/main/java/com/restspotfinder/RestSpotFinderApplication.java
@@ -2,7 +2,9 @@ package com.restspotfinder;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication(scanBasePackages = {"com.restspotfinder", "com.log_module", "com.exception_module"})
 public class RestSpotFinderApplication {
 

--- a/src/main/java/com/restspotfinder/fuel/controller/FuelController.java
+++ b/src/main/java/com/restspotfinder/fuel/controller/FuelController.java
@@ -3,18 +3,21 @@ package com.restspotfinder.fuel.controller;
 import com.restspotfinder.fuel.domain.FuelStation;
 import com.restspotfinder.fuel.service.FuelService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
 @RestController
 @RequestMapping("/fuel")
 @RequiredArgsConstructor
-public class FuelTestController {
+public class FuelController {
 
     private final FuelService fuelService;
 
-    @PostMapping("/update")
+    @PutMapping("/update")
     public String updateFuelStations() {
         fuelService.updateFuelStationsFromApi();
         return "✅ 주유소 데이터가 DB에 저장되었습니다.";

--- a/src/main/java/com/restspotfinder/fuel/controller/FuelTestController.java
+++ b/src/main/java/com/restspotfinder/fuel/controller/FuelTestController.java
@@ -1,0 +1,27 @@
+package com.restspotfinder.fuel.controller;
+
+import com.restspotfinder.fuel.domain.FuelStation;
+import com.restspotfinder.fuel.service.FuelService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/fuel")
+@RequiredArgsConstructor
+public class FuelTestController {
+
+    private final FuelService fuelService;
+
+    @PostMapping("/update")
+    public String updateFuelStations() {
+        fuelService.updateFuelStationsFromApi();
+        return "✅ 주유소 데이터가 DB에 저장되었습니다.";
+    }
+
+    @GetMapping("/all")
+    public List<FuelStation> getAll() {
+        return fuelService.getAllStations();
+    }
+}

--- a/src/main/java/com/restspotfinder/fuel/domain/FuelStation.java
+++ b/src/main/java/com/restspotfinder/fuel/domain/FuelStation.java
@@ -1,0 +1,40 @@
+package com.restspotfinder.fuel.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class FuelStation {
+
+    @Id
+    private String serviceAreaCode; // 영업부대시설코드
+
+    private String serviceAreaName; // 주유소명
+    private String routeName; // 노선명
+    private String direction; // 방향
+    private String gasolinePrice; // 휘발유가격
+    private String diselPrice; // 경유가격
+    private String lpgPrice; // LPG가격
+    private String oilCompany;
+    private String telNo; // 전화번호
+    private String svarAddr; // 휴게소주소
+
+    public FuelStation(String serviceAreaCode, String serviceAreaName, String routeName, String direction,
+                       String gasolinePrice, String diselPrice, String lpgPrice,
+                       String oilCompany, String telNo, String svarAddr) {
+        this.serviceAreaCode = serviceAreaCode;
+        this.serviceAreaName = serviceAreaName;
+        this.routeName = routeName;
+        this.direction = direction;
+        this.gasolinePrice = gasolinePrice;
+        this.diselPrice = diselPrice;
+        this.lpgPrice = lpgPrice;
+        this.oilCompany = oilCompany;
+        this.telNo = telNo;
+        this.svarAddr = svarAddr;
+    }
+}

--- a/src/main/java/com/restspotfinder/fuel/repository/FuelStationRepository.java
+++ b/src/main/java/com/restspotfinder/fuel/repository/FuelStationRepository.java
@@ -1,0 +1,10 @@
+package com.restspotfinder.fuel.repository;
+
+import com.restspotfinder.fuel.domain.FuelStation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface FuelStationRepository extends JpaRepository<FuelStation, String> {
+    Optional<FuelStation> findByServiceAreaName(String serviceAreaName);
+}

--- a/src/main/java/com/restspotfinder/fuel/response/FuelStationResponse.java
+++ b/src/main/java/com/restspotfinder/fuel/response/FuelStationResponse.java
@@ -1,0 +1,28 @@
+package com.restspotfinder.fuel.response;
+
+import com.restspotfinder.fuel.domain.FuelStation;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FuelStationResponse {
+
+    private String serviceAreaName;
+    private String gasolinePrice;
+    private String diselPrice;
+    private String lpgPrice;
+    private String oilCompany;
+    private String telNo;
+
+    public static FuelStationResponse from(FuelStation station) {
+        return FuelStationResponse.builder()
+                .serviceAreaName(station.getServiceAreaName())
+                .gasolinePrice(station.getGasolinePrice())
+                .diselPrice(station.getDiselPrice())
+                .lpgPrice(station.getLpgPrice())
+                .oilCompany(station.getOilCompany())
+                .telNo(station.getTelNo())
+                .build();
+    }
+}

--- a/src/main/java/com/restspotfinder/fuel/scheduler/FuelScheduler.java
+++ b/src/main/java/com/restspotfinder/fuel/scheduler/FuelScheduler.java
@@ -13,7 +13,7 @@ public class FuelScheduler {
     private final FuelService fuelService;
 
     // 매일 자정에 실행
-    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 0 9 * * *", zone = "Asia/Seoul")
     public void updateFuelStationDaliy() {
         log.info("⛽ 연료 정보 스케줄러 실행 시작");
         fuelService.updateFuelStationsFromApi();

--- a/src/main/java/com/restspotfinder/fuel/scheduler/FuelScheduler.java
+++ b/src/main/java/com/restspotfinder/fuel/scheduler/FuelScheduler.java
@@ -1,0 +1,22 @@
+package com.restspotfinder.fuel.scheduler;
+
+import com.restspotfinder.fuel.service.FuelService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FuelScheduler {
+    private final FuelService fuelService;
+
+    // 매일 자정에 실행
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    public void updateFuelStationDaliy() {
+        log.info("⛽ 연료 정보 스케줄러 실행 시작");
+        fuelService.updateFuelStationsFromApi();
+        log.info("✅ 연료 정보 스케줄러 실행 완료");
+    }
+}

--- a/src/main/java/com/restspotfinder/fuel/service/FuelApiClient.java
+++ b/src/main/java/com/restspotfinder/fuel/service/FuelApiClient.java
@@ -1,0 +1,65 @@
+package com.restspotfinder.fuel.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.restspotfinder.fuel.domain.FuelStation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class FuelApiClient {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Value("${ex.api.key}")
+    private String API_KEY;
+    private static final String API_URL = "https://data.ex.co.kr/openapi/business/curStateStation";
+
+    public List<FuelStation> fetchAll() {
+        String uri = UriComponentsBuilder.fromHttpUrl(API_URL)
+                .queryParam("key", API_KEY)
+                .queryParam("type", "json")
+                .queryParam("pageNo", 1)
+                .queryParam("numOfRows", 999)
+                .toUriString();
+
+        List<FuelStation> result = new ArrayList<>();
+
+        try {
+            String response = restTemplate.getForObject(uri, String.class);
+            JsonNode root = objectMapper.readTree(response);
+            JsonNode list = root.path("list");
+
+            if (list.isArray()) {
+                for (JsonNode node : list) {
+                    FuelStation station = new FuelStation(
+                            node.path("serviceAreaCode").asText(),
+                            node.path("serviceAreaName").asText(),
+                            node.path("routeName").asText(),
+                            node.path("direction").asText(),
+                            node.path("gasolinePrice").asText(),
+                            node.path("diselPrice").asText(),
+                            node.path("lpgPrice").asText(),
+                            node.path("oilCompany").asText(),
+                            node.path("telNo").asText(),
+                            node.path("svarAddr").asText()
+                    );
+                    result.add(station);
+                }
+            }
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/com/restspotfinder/fuel/service/FuelService.java
+++ b/src/main/java/com/restspotfinder/fuel/service/FuelService.java
@@ -1,0 +1,33 @@
+package com.restspotfinder.fuel.service;
+
+import com.restspotfinder.fuel.domain.FuelStation;
+import com.restspotfinder.fuel.repository.FuelStationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class FuelService {
+    private final FuelStationRepository fuelStationRepository;
+    private final FuelApiClient fuelApiClient;
+
+    public void updateFuelStationsFromApi() {
+        List<FuelStation> fetchedList = fuelApiClient.fetchAll();
+        fuelStationRepository.saveAll(fetchedList);
+    }
+
+    public Optional<FuelStation> findByServiceAreaName(String name) {
+        return fuelStationRepository.findByServiceAreaName(name);
+    }
+
+    public Optional<FuelStation> findById(String serviceAreaCode) {
+        return fuelStationRepository.findById(serviceAreaCode);
+    }
+
+    public List<FuelStation> getAllStations() {
+        return fuelStationRepository.findAll();
+    }
+}

--- a/src/main/java/com/restspotfinder/fuel/service/FuelService.java
+++ b/src/main/java/com/restspotfinder/fuel/service/FuelService.java
@@ -4,6 +4,8 @@ import com.restspotfinder.fuel.domain.FuelStation;
 import com.restspotfinder.fuel.repository.FuelStationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 import java.util.List;
 import java.util.Optional;
@@ -19,12 +21,12 @@ public class FuelService {
         fuelStationRepository.saveAll(fetchedList);
     }
 
-    public Optional<FuelStation> findByServiceAreaName(String name) {
-        return fuelStationRepository.findByServiceAreaName(name);
-    }
-
-    public Optional<FuelStation> findById(String serviceAreaCode) {
-        return fuelStationRepository.findById(serviceAreaCode);
+    public FuelStation findByServiceAreaName(String name) {
+        return fuelStationRepository.findByServiceAreaName(name)
+                .orElseThrow(() -> new ResponseStatusException(
+                        NOT_FOUND,
+                        String.format("'%s' 이름의 주유소를 찾을 수 없습니다.", name)
+                ));
     }
 
     public List<FuelStation> getAllStations() {


### PR DESCRIPTION
## 💡 개요 (필수)
휴게소 내 주유소 데이터를 매일 자정 DB에 저장
<br/>

## 📃 작업내용 (필수)
- 주유소 정보 저장
  - 한국도로공사 open api를 이용해 주유소 정보 조회
  - DB에 주유소 정보 저장
- 자동화 로직 추가
  - 위 작업의 API 호출이 매일 자정 자동으로 이루어지도록 스케줄러 추가
<br/>

## 🔀 변경사항 (선택)
- `RestSpotFinderApplication`에 `@EnableScheduling` 추가
- yml에 openapi key 추가
<br/>
