### PR TITLE
Feat detail page

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,11 +49,11 @@ dependencies {
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 
-    // 크롤러
-    implementation 'org.seleniumhq.selenium:selenium-java:4.15.0'
-    implementation 'io.github.bonigarcia:webdrivermanager:5.6.2'
-    implementation 'org.jsoup:jsoup:1.16.2'
-    implementation 'org.apache.commons:commons-io:1.3.2'
+//    // 크롤러
+//    implementation 'org.seleniumhq.selenium:selenium-java:4.15.0'
+//    implementation 'io.github.bonigarcia:webdrivermanager:5.6.2'
+//    implementation 'org.jsoup:jsoup:1.16.2'
+//    implementation 'org.apache.commons:commons-io:1.3.2'
 }
 
 tasks.named('bootJar') {

--- a/src/main/java/com/restspotfinder/config/WebDriverConfig.java
+++ b/src/main/java/com/restspotfinder/config/WebDriverConfig.java
@@ -1,29 +1,29 @@
-package com.restspotfinder.common.config;
-
-import io.github.bonigarcia.wdm.WebDriverManager;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.chrome.ChromeDriver;
-import org.openqa.selenium.chrome.ChromeOptions;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-
-
-@Configuration
-public class WebDriverConfig {
-
-    @Bean
-    public WebDriver webDriver() {
-        WebDriverManager.chromedriver().setup();
-
-        ChromeOptions options = new ChromeOptions();
-        options.addArguments("--headless");
-        options.addArguments("--no-sandbox");
-        options.addArguments("--disable-dev-shm-usage");
-        options.addArguments("--disable-gpu");
-        options.addArguments("--window-size=1920,1080");
-
-        // 더 현실적인 User-Agent 사용
-        options.addArguments("--user-agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36");
-        return new ChromeDriver(options);
-    }
-}
+//package com.restspotfinder.common.config;
+//
+//import io.github.bonigarcia.wdm.WebDriverManager;
+//import org.openqa.selenium.WebDriver;
+//import org.openqa.selenium.chrome.ChromeDriver;
+//import org.openqa.selenium.chrome.ChromeOptions;
+//import org.springframework.context.annotation.Bean;
+//import org.springframework.context.annotation.Configuration;
+//
+//
+//@Configuration
+//public class WebDriverConfig {
+//
+//    @Bean
+//    public WebDriver webDriver() {
+//        WebDriverManager.chromedriver().setup();
+//
+//        ChromeOptions options = new ChromeOptions();
+//        options.addArguments("--headless");
+//        options.addArguments("--no-sandbox");
+//        options.addArguments("--disable-dev-shm-usage");
+//        options.addArguments("--disable-gpu");
+//        options.addArguments("--window-size=1920,1080");
+//
+//        // 더 현실적인 User-Agent 사용
+//        options.addArguments("--user-agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36");
+//        return new ChromeDriver(options);
+//    }
+//}

--- a/src/main/java/com/restspotfinder/domain/apicount/service/ApiCountService.java
+++ b/src/main/java/com/restspotfinder/domain/apicount/service/ApiCountService.java
@@ -24,7 +24,7 @@ public class ApiCountService {
     @Transactional
     public void checkPlaceSearchCount(LocalDate today) {
         PlaceSearchCount placeSearchCount = placeSearchCountRepository.findByDateWithPessimisticLock(today)
-                .orElse(PlaceSearchCount.init(LocalDate.now()));
+                .orElse(PlaceSearchCount.init(today));
 
         long apiCallCount = placeSearchCount.getNaverCount();
         if (apiCallCount >= 25000) // 일일 한도 25,000 건
@@ -51,7 +51,7 @@ public class ApiCountService {
     @Transactional
     public void checkAddressSearchCount(LocalDate today) {
         AddressSearchCount addressSearchCount = addressSearchCountRepository.findByCreatedAt(today)
-                .orElse(AddressSearchCount.init(LocalDate.now()));
+                .orElse(AddressSearchCount.init(today));
 
         long apiCallCount = addressSearchCount.getNaverCount();
         if (apiCallCount >= 25000) // 일일 한도 25,000 건

--- a/src/main/java/com/restspotfinder/domain/fuel/entity/FuelUpdateHistory.java
+++ b/src/main/java/com/restspotfinder/domain/fuel/entity/FuelUpdateHistory.java
@@ -1,0 +1,32 @@
+package com.restspotfinder.domain.fuel.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FuelUpdateHistory {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private Boolean isSuccess;
+    private Integer updatedCount;
+    private LocalDateTime updateStartedAt;
+
+    public static FuelUpdateHistory create(Boolean isSuccess, Integer updatedCount) {
+        return FuelUpdateHistory.builder()
+                .isSuccess(isSuccess)
+                .updatedCount(updatedCount)
+                .updateStartedAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/main/java/com/restspotfinder/domain/fuel/error/FuelErrorCode.java
+++ b/src/main/java/com/restspotfinder/domain/fuel/error/FuelErrorCode.java
@@ -8,9 +8,11 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum FuelErrorCode implements ErrorCode {
-    NOT_FOUND("FUEL_NOT_FOUND", "해당 주유소를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+    NOT_FOUND("FUEL_NOT_FOUND", "해당 주유소를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    API_DATA_EMPTY("FUEL_API_DATA_EMPTY", "API에서 가져온 주유소 데이터가 비어있습니다.", HttpStatus.BAD_REQUEST),
+    UPDATE_FAILED("FUEL_UPDATE_FAILED", "주유소 가격 데이터 업데이트에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final String code;
     private final String message;
     private final HttpStatus httpStatus;
-} 
+}

--- a/src/main/java/com/restspotfinder/domain/fuel/repository/FuelUpdateHistoryRepository.java
+++ b/src/main/java/com/restspotfinder/domain/fuel/repository/FuelUpdateHistoryRepository.java
@@ -3,6 +3,8 @@ package com.restspotfinder.domain.fuel.repository;
 import com.restspotfinder.domain.fuel.entity.FuelUpdateHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
 
 public interface FuelUpdateHistoryRepository extends JpaRepository<FuelUpdateHistory, Long> {
+    Optional<FuelUpdateHistory> findFirstByIsSuccessTrueOrderByUpdateStartedAtDesc();
 }

--- a/src/main/java/com/restspotfinder/domain/fuel/repository/FuelUpdateHistoryRepository.java
+++ b/src/main/java/com/restspotfinder/domain/fuel/repository/FuelUpdateHistoryRepository.java
@@ -1,0 +1,8 @@
+package com.restspotfinder.domain.fuel.repository;
+
+import com.restspotfinder.domain.fuel.entity.FuelUpdateHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface FuelUpdateHistoryRepository extends JpaRepository<FuelUpdateHistory, Long> {
+}

--- a/src/main/java/com/restspotfinder/domain/fuel/service/FuelService.java
+++ b/src/main/java/com/restspotfinder/domain/fuel/service/FuelService.java
@@ -1,17 +1,24 @@
 package com.restspotfinder.domain.fuel.service;
 
 import com.restspotfinder.domain.fuel.entity.FuelStation;
+import com.restspotfinder.domain.fuel.entity.FuelUpdateHistory;
 import com.restspotfinder.domain.fuel.repository.FuelStationRepository;
+import com.restspotfinder.domain.fuel.repository.FuelUpdateHistoryRepository;
+import com.restspotfinder.exception.BusinessException;
+import com.restspotfinder.domain.fuel.error.FuelErrorCode;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class FuelService {
     private final FuelStationRepository fuelStationRepository;
+    private final FuelUpdateHistoryRepository fuelUpdateHistoryRepository;
     private final FuelApiClient fuelApiClient;
 
     public List<FuelStation> getAll() {
@@ -20,7 +27,28 @@ public class FuelService {
 
     @Transactional
     public void updateFuelStationsFromApi() {
-        List<FuelStation> fetchedList = fuelApiClient.fetchAll();
-        fuelStationRepository.saveAll(fetchedList);
+        try {
+            List<FuelStation> fetchedList = fuelApiClient.fetchAll();
+            
+            if (fetchedList == null || fetchedList.isEmpty()) {
+                FuelUpdateHistory history = FuelUpdateHistory.create(false, 0);
+                fuelUpdateHistoryRepository.save(history);
+
+                throw new BusinessException(FuelErrorCode.API_DATA_EMPTY);
+            }
+            
+            List<FuelStation> savedList = fuelStationRepository.saveAll(fetchedList);
+
+            FuelUpdateHistory history = FuelUpdateHistory.create(true, savedList.size());
+            fuelUpdateHistoryRepository.save(history);
+            log.info("주유소 가격 데이터 업데이트 완료 - 업데이트된 데이터: {}건", savedList.size());
+            
+        } catch (Exception e) {
+            FuelUpdateHistory history = FuelUpdateHistory.create(false, 0);
+            fuelUpdateHistoryRepository.save(history);
+
+            log.error("주유소 가격 데이터 업데이트 예상치 못한 오류: {}", e.getMessage());
+            throw new BusinessException(FuelErrorCode.UPDATE_FAILED, e);
+        }
     }
 }

--- a/src/main/java/com/restspotfinder/domain/place/service/NaverAddressService.java
+++ b/src/main/java/com/restspotfinder/domain/place/service/NaverAddressService.java
@@ -34,14 +34,11 @@ public class NaverAddressService {
     @Value("${naver.cloud-platform.client-secret}")
     String CLOUD_CLIENT_SECRET;
 
-    // 일일 허용량 25,000 건
-    public void checkAddressSearchCount() {
-        // 일일 한도 25,000 건
-        apiCountService.checkAddressSearchCount(LocalDate.now());
-    }
 
     @Transactional
     public List<NaverPlace> getPlaceListByAddress(String address) {
+        apiCountService.checkAddressSearchCount(LocalDate.now());
+        
         String requestURL = REQUEST_URL + "?query=" + address;
         JsonNode jsonNode = connectCloud(requestURL);
 

--- a/src/main/java/com/restspotfinder/domain/place/service/NaverPlaceService.java
+++ b/src/main/java/com/restspotfinder/domain/place/service/NaverPlaceService.java
@@ -32,13 +32,10 @@ public class NaverPlaceService {
     @Value("${naver.developers.client-secret}")
     String CLIENT_SECRET;
 
-    // 일일 허용량 25,000 건
-    public void checkPlaceSearchCount() {
-        // 일일 한도 25,000 건
-        apiCountService.checkPlaceSearchCount(LocalDate.now());
-    }
     @Transactional
     public List<NaverPlace> getPlaceListBySearchTerm(String searchTerm) {
+        apiCountService.checkPlaceSearchCount(LocalDate.now());
+        
         String requestURL = SEARCH_URL + "?display=5&query=" + searchTerm;
         JsonNode jsonNode = connect(requestURL);
 

--- a/src/main/java/com/restspotfinder/domain/restarea/controller/RestAreaController.java
+++ b/src/main/java/com/restspotfinder/domain/restarea/controller/RestAreaController.java
@@ -1,6 +1,7 @@
 package com.restspotfinder.domain.restarea.controller;
 
 import com.restspotfinder.domain.restarea.dto.RestAreaResponse;
+import com.restspotfinder.domain.restarea.dto.RestAreaDetailResponse;
 import com.restspotfinder.domain.restarea.service.RestAreaService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -22,12 +23,11 @@ import java.util.List;
 public class RestAreaController {
     private final RestAreaService restAreaService;
 
-    @Operation(summary = "단 건 휴게소 조회 API")
-    @ApiResponse(responseCode = "200", content = {@Content(mediaType = "application/json", array =
-    @ArraySchema(schema = @Schema(implementation = RestAreaResponse.class)))})
+    @Operation(summary = "단 건 휴게소 상세 조회 API")
+    @ApiResponse(responseCode = "200", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = RestAreaDetailResponse.class))})
     @GetMapping
-    public ResponseEntity<?> getOneByRestAreaId(@RequestParam long restAreaId) {
-        RestAreaResponse response = restAreaService.getOneById(restAreaId);
+    public ResponseEntity<RestAreaDetailResponse> getOneByRestAreaId(@RequestParam long restAreaId) {
+        RestAreaDetailResponse response = restAreaService.getDetailById(restAreaId);
         
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/restspotfinder/domain/restarea/controller/RestAreaCrawlerController.java
+++ b/src/main/java/com/restspotfinder/domain/restarea/controller/RestAreaCrawlerController.java
@@ -1,93 +1,93 @@
-package com.restspotfinder.domain.restarea.controller;
-
-import com.restspotfinder.domain.restarea.entity.RestArea;
-import com.restspotfinder.domain.restarea.repository.RestAreaRepository;
-import com.restspotfinder.domain.restarea.service.RestAreaImageCrawlerService;
-import com.restspotfinder.restarea.response.CrawlResult;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-import com.restspotfinder.exception.BusinessException;
-import com.restspotfinder.domain.restarea.error.RestAreaErrorCode;
-
-import java.util.HashMap;
-import java.util.Map;
-
-@RestController
-@RequestMapping("/api/restarea-crawler")
-@Slf4j
-public class RestAreaCrawlerController {
-
-    private final RestAreaImageCrawlerService crawlerService;
-    private final RestAreaRepository restAreaRepository;
-
-    public RestAreaCrawlerController(RestAreaImageCrawlerService crawlerService,
-                                     RestAreaRepository restAreaRepository) {
-        this.crawlerService = crawlerService;
-        this.restAreaRepository = restAreaRepository;
-    }
-
-    @PostMapping("/crawl-images")
-    public ResponseEntity<CrawlResult> crawlAllImages() {
-        try {
-            log.info("RestArea 이미지 크롤링 시작");
-
-            CrawlResult result = crawlerService.crawlAllRestAreaImages();
-            result.setMessage(String.format("크롤링 완료 - 성공: %d개, 실패: %d개, 성공률: %.1f%%",
-                    result.getSuccessCount(),
-                    result.getFailCount(),
-                    result.getSuccessRate()));
-
-            return ResponseEntity.ok(result);
-
-        } catch (Exception e) {
-            log.error("크롤링 요청 처리 실패: {}", e.getMessage(), e);
-
-            CrawlResult errorResult = CrawlResult.builder()
-                    .totalCount(0)
-                    .successCount(0)
-                    .failCount(0)
-                    .message("크롤링 중 오류가 발생했습니다: " + e.getMessage())
-                    .build();
-
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResult);
-        }
-    }
-
-
-    @PostMapping("/crawl-single/{restAreaId}")
-    public ResponseEntity<Map<String, Object>> crawlSingleRestArea(@PathVariable Long restAreaId) {
-        try {
-            RestArea restArea = restAreaRepository.findById(restAreaId)
-                    .orElseThrow(() -> new BusinessException(RestAreaErrorCode.NOT_FOUND));
-
-            if (restArea.getNaverMapUrl() == null) {
-                throw new BusinessException(RestAreaErrorCode.NAVER_MAP_URL_NOT_FOUND);
-            }
-
-            String imageUrl = crawlerService.crawlImageFromNaverMap(restArea.getNaverMapUrl());
-
-            Map<String, Object> result = new HashMap<>();
-            if (imageUrl != null) {
-                restArea.setMainImg(imageUrl);
-                restAreaRepository.save(restArea);
-
-                result.put("success", true);
-                result.put("imageUrl", imageUrl);
-                result.put("message", "이미지 URL 수집 완료");
-            } else {
-                result.put("success", false);
-                result.put("message", "이미지를 찾을 수 없습니다.");
-            }
-
-            return ResponseEntity.ok(result);
-
-        } catch (Exception e) {
-            Map<String, Object> errorResult = new HashMap<>();
-            errorResult.put("success", false);
-            errorResult.put("message", e.getMessage());
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResult);
-        }
-    }
-}
+//package com.restspotfinder.domain.restarea.controller;
+//
+//import com.restspotfinder.domain.restarea.entity.RestArea;
+//import com.restspotfinder.domain.restarea.repository.RestAreaRepository;
+//import com.restspotfinder.domain.restarea.service.RestAreaImageCrawlerService;
+//import com.restspotfinder.restarea.response.CrawlResult;
+//import lombok.extern.slf4j.Slf4j;
+//import org.springframework.http.HttpStatus;
+//import org.springframework.http.ResponseEntity;
+//import org.springframework.web.bind.annotation.*;
+//import com.restspotfinder.exception.BusinessException;
+//import com.restspotfinder.domain.restarea.error.RestAreaErrorCode;
+//
+//import java.util.HashMap;
+//import java.util.Map;
+//
+//@RestController
+//@RequestMapping("/api/restarea-crawler")
+//@Slf4j
+//public class RestAreaCrawlerController {
+//
+//    private final RestAreaImageCrawlerService crawlerService;
+//    private final RestAreaRepository restAreaRepository;
+//
+//    public RestAreaCrawlerController(RestAreaImageCrawlerService crawlerService,
+//                                     RestAreaRepository restAreaRepository) {
+//        this.crawlerService = crawlerService;
+//        this.restAreaRepository = restAreaRepository;
+//    }
+//
+//    @PostMapping("/crawl-images")
+//    public ResponseEntity<CrawlResult> crawlAllImages() {
+//        try {
+//            log.info("RestArea 이미지 크롤링 시작");
+//
+//            CrawlResult result = crawlerService.crawlAllRestAreaImages();
+//            result.setMessage(String.format("크롤링 완료 - 성공: %d개, 실패: %d개, 성공률: %.1f%%",
+//                    result.getSuccessCount(),
+//                    result.getFailCount(),
+//                    result.getSuccessRate()));
+//
+//            return ResponseEntity.ok(result);
+//
+//        } catch (Exception e) {
+//            log.error("크롤링 요청 처리 실패: {}", e.getMessage(), e);
+//
+//            CrawlResult errorResult = CrawlResult.builder()
+//                    .totalCount(0)
+//                    .successCount(0)
+//                    .failCount(0)
+//                    .message("크롤링 중 오류가 발생했습니다: " + e.getMessage())
+//                    .build();
+//
+//            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResult);
+//        }
+//    }
+//
+//
+//    @PostMapping("/crawl-single/{restAreaId}")
+//    public ResponseEntity<Map<String, Object>> crawlSingleRestArea(@PathVariable Long restAreaId) {
+//        try {
+//            RestArea restArea = restAreaRepository.findById(restAreaId)
+//                    .orElseThrow(() -> new BusinessException(RestAreaErrorCode.NOT_FOUND));
+//
+//            if (restArea.getNaverMapUrl() == null) {
+//                throw new BusinessException(RestAreaErrorCode.NAVER_MAP_URL_NOT_FOUND);
+//            }
+//
+//            String imageUrl = crawlerService.crawlImageFromNaverMap(restArea.getNaverMapUrl());
+//
+//            Map<String, Object> result = new HashMap<>();
+//            if (imageUrl != null) {
+//                restArea.setMainImg(imageUrl);
+//                restAreaRepository.save(restArea);
+//
+//                result.put("success", true);
+//                result.put("imageUrl", imageUrl);
+//                result.put("message", "이미지 URL 수집 완료");
+//            } else {
+//                result.put("success", false);
+//                result.put("message", "이미지를 찾을 수 없습니다.");
+//            }
+//
+//            return ResponseEntity.ok(result);
+//
+//        } catch (Exception e) {
+//            Map<String, Object> errorResult = new HashMap<>();
+//            errorResult.put("success", false);
+//            errorResult.put("message", e.getMessage());
+//            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResult);
+//        }
+//    }
+//}

--- a/src/main/java/com/restspotfinder/domain/restarea/dto/RestAreaDetailResponse.java
+++ b/src/main/java/com/restspotfinder/domain/restarea/dto/RestAreaDetailResponse.java
@@ -1,0 +1,138 @@
+package com.restspotfinder.domain.restarea.dto;
+
+import com.restspotfinder.domain.restarea.entity.RestArea;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class RestAreaDetailResponse {
+    @Schema(description = "휴게소 고유 ID")
+    private Long restAreaId;
+    
+    @Schema(description = "휴게소 명")
+    private String name;
+    
+    @Schema(description = "도로 명")
+    private String routeName;
+    
+    @Schema(description = "방향", example = "상행, 하행, 양방향")
+    private String routeDirection;
+    
+    @Schema(description = "위도")
+    private double lat;
+    
+    @Schema(description = "경도")
+    private double lng;
+    
+    @Schema(description = "휴게소 종류")
+    private String type;
+    
+    @Schema(description = "휴게소 운영 시작 시각")
+    private String operatingStartTime;
+    
+    @Schema(description = "휴게소 운영 종료 시각")
+    private String operatingEndTime;
+    
+    @Schema(description = "주차면 수")
+    private int parkingSpaceCount;
+    
+    @Schema(description = "경정비 가능 여부")
+    private Boolean isMaintenanceAvailable;
+    
+    @Schema(description = "주유소 유무")
+    private Boolean hasGasStation;
+    
+    @Schema(description = "LPG 충전소 유무")
+    private Boolean hasLpgChargingStation;
+    
+    @Schema(description = "전기차 충전소 유무")
+    private Boolean hasElectricChargingStation;
+    
+    @Schema(description = "화장실 유무")
+    private Boolean hasRestroom;
+    
+    @Schema(description = "약국 유무")
+    private Boolean hasPharmacy;
+    
+    @Schema(description = "수유실 유무")
+    private Boolean hasNursingRoom;
+    
+    @Schema(description = "매점 유무")
+    private Boolean hasStore;
+    
+    @Schema(description = "음식점 유무")
+    private Boolean hasRestaurant;
+    
+    @Schema(description = "기타 편의 시설")
+    private String otherFacilities;
+    
+    @Schema(description = "휴게소 대표 음식명")
+    private String representativeFood;
+    
+    @Schema(description = "휴게소 전화 번호")
+    private String phoneNumber;
+    
+    @Schema(description = "매칭되는 NAVER MAP URL")
+    private String naverMapUrl;
+    
+    @Schema(description = "휴게소 대표 이미지")
+    private String mainImage;
+    
+    @Schema(description = "주유소 가격 정보 존재 여부")
+    private Boolean hasFuelData;
+    
+    @Schema(description = "주유소 가격 정보 최근 업데이트 날짜")
+    private LocalDateTime lastFuelUpdateDate;
+    
+    @Schema(description = "휘발유 가격")
+    private String gasolinePrice;
+    
+    @Schema(description = "경유 가격")
+    private String dieselPrice;
+    
+    @Schema(description = "LPG 가격")
+    private String lpgPrice;
+    
+    public static RestAreaDetailResponse of(RestArea restArea, LocalDateTime lastFuelUpdateDate) {
+        boolean hasFuelData = restArea.getFuelStation() != null;
+        String gasolinePrice = hasFuelData ?  restArea.getFuelStation().getGasolinePrice() : null;
+        String dieselPrice = hasFuelData ?  restArea.getFuelStation().getDiselPrice() : null;
+        String lpgPrice = hasFuelData ?  restArea.getFuelStation().getLpgPrice() : null;
+
+        return RestAreaDetailResponse.builder()
+                .restAreaId(restArea.getRestAreaId())
+                .name(restArea.getName())
+                .routeName(restArea.getRouteName())
+                .routeDirection(restArea.getRouteDirection())
+                .lat(restArea.getLatitude())
+                .lng(restArea.getLongitude())
+                .type(restArea.getType())
+                .operatingStartTime(restArea.getOperatingStartTime())
+                .operatingEndTime(restArea.getOperatingEndTime())
+                .parkingSpaceCount(restArea.getParkingSpaceCount())
+                .isMaintenanceAvailable(restArea.getIsMaintenanceAvailable())
+                .hasGasStation(restArea.getHasGasStation())
+                .hasLpgChargingStation(restArea.getHasLpgChargingStation())
+                .hasElectricChargingStation(restArea.getHasElectricChargingStation())
+                .hasRestroom(restArea.getHasRestroom())
+                .hasPharmacy(restArea.getHasPharmacy())
+                .hasNursingRoom(restArea.getHasNursingRoom())
+                .hasStore(restArea.getHasStore())
+                .hasRestaurant(restArea.getHasRestaurant())
+                .otherFacilities(restArea.getOtherFacilities())
+                .representativeFood(restArea.getRepresentativeFood())
+                .phoneNumber(restArea.getPhoneNumber())
+                .naverMapUrl(restArea.getNaverMapUrl())
+                .mainImage(restArea.getMainImg())
+                .hasFuelData(hasFuelData)
+                .lastFuelUpdateDate(lastFuelUpdateDate)
+                .gasolinePrice(gasolinePrice)
+                .dieselPrice(dieselPrice)
+                .lpgPrice(lpgPrice)
+                .build();
+    }
+}

--- a/src/main/java/com/restspotfinder/domain/restarea/entity/RestArea.java
+++ b/src/main/java/com/restspotfinder/domain/restarea/entity/RestArea.java
@@ -3,6 +3,7 @@ package com.restspotfinder.domain.restarea.entity;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.restspotfinder.domain.route.enums.Direction;
+import com.restspotfinder.domain.fuel.entity.FuelStation;
 import jakarta.persistence.*;
 import lombok.*;
 import org.locationtech.jts.geom.Coordinate;
@@ -54,14 +55,11 @@ public class RestArea {
     private String naverMapUrl; // 매칭되는 네이버 맵 페이지 URL
 
     private String mainImg; // 네이버맵 대표 이미지 src
+    
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "fuelId", referencedColumnName = "serviceAreaCode", insertable = false, updatable = false)
+    private FuelStation fuelStation;
 
-    public String getMainImg() {
-        return mainImg;
-    }
-
-    public void setMainImg(String mainImg) {
-        this.mainImg = mainImg;
-    }
 
     public boolean isAccessible(Direction routeDirectionFromRoute) {
         return routeDirectionFromRoute != null &&

--- a/src/main/java/com/restspotfinder/domain/restarea/entity/RestArea.java
+++ b/src/main/java/com/restspotfinder/domain/restarea/entity/RestArea.java
@@ -60,7 +60,6 @@ public class RestArea {
     @JoinColumn(name = "fuelId", referencedColumnName = "serviceAreaCode", insertable = false, updatable = false)
     private FuelStation fuelStation;
 
-
     public boolean isAccessible(Direction routeDirectionFromRoute) {
         return routeDirectionFromRoute != null &&
                 (

--- a/src/main/java/com/restspotfinder/domain/restarea/repository/RestAreaRepository.java
+++ b/src/main/java/com/restspotfinder/domain/restarea/repository/RestAreaRepository.java
@@ -8,9 +8,13 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface RestAreaRepository extends JpaRepository<RestArea, Long> {
     List<RestArea> findByRouteName(String routeName);
+    
+    @Query("SELECT r FROM RestArea r LEFT JOIN FETCH r.fuelStation WHERE r.restAreaId = :restAreaId")
+    Optional<RestArea> findByIdWithFuelStation(@Param("restAreaId") Long restAreaId);
 
     /***
      * 경로 LineString <-> 휴게소 좌표 비교 (500m 이내에 있는지 체크)

--- a/src/main/java/com/restspotfinder/domain/restarea/service/RestAreaImageCrawlerService.java
+++ b/src/main/java/com/restspotfinder/domain/restarea/service/RestAreaImageCrawlerService.java
@@ -1,251 +1,251 @@
-package com.restspotfinder.domain.restarea.service;
-
-import com.restspotfinder.domain.restarea.entity.RestArea;
-import com.restspotfinder.domain.restarea.repository.RestAreaRepository;
-import com.restspotfinder.restarea.response.CrawlResult;
-import jakarta.annotation.PreDestroy;
-import jakarta.transaction.Transactional;
-import lombok.extern.slf4j.Slf4j;
-import org.openqa.selenium.*;
-import org.openqa.selenium.support.ui.ExpectedConditions;
-import org.openqa.selenium.support.ui.WebDriverWait;
-import org.springframework.stereotype.Service;
-
-import java.time.Duration;
-import java.util.List;
-
-@Service
-@Slf4j
-@Transactional
-public class RestAreaImageCrawlerService {
-
-    private final WebDriver webDriver;
-    private final RestAreaRepository restAreaRepository;
-
-    public RestAreaImageCrawlerService(WebDriver webDriver, RestAreaRepository restAreaRepository) {
-        this.webDriver = webDriver;
-        this.restAreaRepository = restAreaRepository;
-    }
-
-    public CrawlResult crawlAllRestAreaImages() {
-        List<RestArea> restAreas = restAreaRepository.findAll();
-        int successCount = 0;
-        int failCount = 0;
-
-        log.info("네이버 지도 URL이 있는 휴게소 {}개 처리 시작", restAreas.size());
-
-        for (RestArea restArea : restAreas) {
-            try {
-                if (restArea.getMainImg() == null) {
-                    String imageUrl = crawlImageFromNaverMap(restArea.getNaverMapUrl());
-
-                    if (imageUrl != null) {
-                        restArea.setMainImg(imageUrl);
-                        restAreaRepository.save(restArea);
-                        successCount++;
-                        System.out.println("휴게소 = " + restArea.getName() + "image = " + imageUrl);
-                        log.info("휴게소 '{}' 이미지 URL 수집 완료: {}", restArea.getName(), imageUrl);
-                    } else {
-                        failCount++;
-                        System.err.println("휴게소 = " + restArea.getName() + " 실패");
-                        log.warn("휴게소 '{}' 이미지 URL 수집 실패", restArea.getName());
-                    }
-                } else {
-                    log.debug("휴게소 '{}' 이미지 URL 이미 존재", restArea.getName());
-                }
-
-                // 요청 간격 조절 (1초 대기)
-                Thread.sleep(1000);
-
-            } catch (Exception e) {
-                failCount++;
-                log.error("휴게소 '{}' 처리 중 오류: {}", restArea.getName(), e.getMessage(), e);
-            }
-        }
-
-        return CrawlResult.builder()
-                .totalCount(restAreas.size())
-                .successCount(successCount)
-                .failCount(failCount)
-                .build();
-    }
-
-    public String crawlImageFromNaverMap(String naverMapUrl) {
-        if (naverMapUrl == null || naverMapUrl.trim().isEmpty()) {
-            return null;
-        }
-
-        try {
-            webDriver.get(naverMapUrl);
-
-            // 페이지 로딩 대기
-            WebDriverWait wait = new WebDriverWait(webDriver, Duration.ofSeconds(10));
-
-            // 이미지 요소들을 찾기 위한 여러 시도
-            String imageUrl = null;
-
-            // 방법 1: place_thumb QX0J7 클래스를 가진 a 태그에서 img 추출
-            imageUrl = findImageBySpecificATag();
-            if (imageUrl != null) return imageUrl;
-
-            log.info("네이버 지도 URL에서 이미지를 찾을 수 없음: {}", naverMapUrl);
-            return null;
-
-        } catch (Exception e) {
-            log.error("네이버 지도 크롤링 중 오류: {}", e.getMessage(), e);
-            return null;
-        }
-    }
-
-    private String findImageBySpecificATag() {
-        try {
-            WebDriverWait wait = new WebDriverWait(webDriver, Duration.ofSeconds(10));
-
-            // entryIframe으로 switch
-            wait.until(ExpectedConditions.frameToBeAvailableAndSwitchToIt("entryIframe"));
-
-            // iframe 내부에서 페이지 로딩 대기
-            Thread.sleep(3000);
-
-            // place_thumb QX0J7 클래스를 가진 a 태그 찾기
-            List<WebElement> aElements = webDriver.findElements(By.cssSelector("a.place_thumb.QX0J7"));
-
-            for (WebElement aElement : aElements) {
-                // a 태그 내부의 img 태그 찾기
-                List<WebElement> imgElements = aElement.findElements(By.tagName("img"));
-
-                for (WebElement img : imgElements) {
-                    String src = img.getAttribute("src");
-                    if (isValidImageUrl(src)) {
-                        log.info("유효한 이미지 URL 발견: {}", src);
-                        return src;
-                    }
-                }
-            }
-
-        } catch (Exception e) {
-            log.warn("place_thumb QX0J7 클래스 검색 중 오류: {}", e.getMessage());
-        } finally {
-            // 메인 프레임으로 다시 전환
-            try {
-                webDriver.switchTo().defaultContent();
-            } catch (Exception e) {
-                log.warn("메인 프레임 전환 실패: {}", e.getMessage());
-            }
-        }
-        return null;
-    }
-
-//    private String findImageBySpecificATag() {
-//        System.out.println("findImageBySpecificATag 들어옴");
+//package com.restspotfinder.domain.restarea.service;
+//
+//import com.restspotfinder.domain.restarea.entity.RestArea;
+//import com.restspotfinder.domain.restarea.repository.RestAreaRepository;
+//import com.restspotfinder.restarea.response.CrawlResult;
+//import jakarta.annotation.PreDestroy;
+//import jakarta.transaction.Transactional;
+//import lombok.extern.slf4j.Slf4j;
+//import org.openqa.selenium.*;
+//import org.openqa.selenium.support.ui.ExpectedConditions;
+//import org.openqa.selenium.support.ui.WebDriverWait;
+//import org.springframework.stereotype.Service;
+//
+//import java.time.Duration;
+//import java.util.List;
+//
+//@Service
+//@Slf4j
+//@Transactional
+//public class RestAreaImageCrawlerService {
+//
+//    private final WebDriver webDriver;
+//    private final RestAreaRepository restAreaRepository;
+//
+//    public RestAreaImageCrawlerService(WebDriver webDriver, RestAreaRepository restAreaRepository) {
+//        this.webDriver = webDriver;
+//        this.restAreaRepository = restAreaRepository;
+//    }
+//
+//    public CrawlResult crawlAllRestAreaImages() {
+//        List<RestArea> restAreas = restAreaRepository.findAll();
+//        int successCount = 0;
+//        int failCount = 0;
+//
+//        log.info("네이버 지도 URL이 있는 휴게소 {}개 처리 시작", restAreas.size());
+//
+//        for (RestArea restArea : restAreas) {
+//            try {
+//                if (restArea.getMainImg() == null) {
+//                    String imageUrl = crawlImageFromNaverMap(restArea.getNaverMapUrl());
+//
+//                    if (imageUrl != null) {
+//                        restArea.setMainImg(imageUrl);
+//                        restAreaRepository.save(restArea);
+//                        successCount++;
+//                        System.out.println("휴게소 = " + restArea.getName() + "image = " + imageUrl);
+//                        log.info("휴게소 '{}' 이미지 URL 수집 완료: {}", restArea.getName(), imageUrl);
+//                    } else {
+//                        failCount++;
+//                        System.err.println("휴게소 = " + restArea.getName() + " 실패");
+//                        log.warn("휴게소 '{}' 이미지 URL 수집 실패", restArea.getName());
+//                    }
+//                } else {
+//                    log.debug("휴게소 '{}' 이미지 URL 이미 존재", restArea.getName());
+//                }
+//
+//                // 요청 간격 조절 (1초 대기)
+//                Thread.sleep(1000);
+//
+//            } catch (Exception e) {
+//                failCount++;
+//                log.error("휴게소 '{}' 처리 중 오류: {}", restArea.getName(), e.getMessage(), e);
+//            }
+//        }
+//
+//        return CrawlResult.builder()
+//                .totalCount(restAreas.size())
+//                .successCount(successCount)
+//                .failCount(failCount)
+//                .build();
+//    }
+//
+//    public String crawlImageFromNaverMap(String naverMapUrl) {
+//        if (naverMapUrl == null || naverMapUrl.trim().isEmpty()) {
+//            return null;
+//        }
+//
 //        try {
-//            WebDriverWait wait = new WebDriverWait(webDriver, Duration.ofSeconds(20));
+//            webDriver.get(naverMapUrl);
+//
+//            // 페이지 로딩 대기
+//            WebDriverWait wait = new WebDriverWait(webDriver, Duration.ofSeconds(10));
+//
+//            // 이미지 요소들을 찾기 위한 여러 시도
+//            String imageUrl = null;
+//
+//            // 방법 1: place_thumb QX0J7 클래스를 가진 a 태그에서 img 추출
+//            imageUrl = findImageBySpecificATag();
+//            if (imageUrl != null) return imageUrl;
+//
+//            log.info("네이버 지도 URL에서 이미지를 찾을 수 없음: {}", naverMapUrl);
+//            return null;
+//
+//        } catch (Exception e) {
+//            log.error("네이버 지도 크롤링 중 오류: {}", e.getMessage(), e);
+//            return null;
+//        }
+//    }
+//
+//    private String findImageBySpecificATag() {
+//        try {
+//            WebDriverWait wait = new WebDriverWait(webDriver, Duration.ofSeconds(10));
+//
+//            // entryIframe으로 switch
+//            wait.until(ExpectedConditions.frameToBeAvailableAndSwitchToIt("entryIframe"));
+//
+//            // iframe 내부에서 페이지 로딩 대기
+//            Thread.sleep(3000);
 //
 //            // place_thumb QX0J7 클래스를 가진 a 태그 찾기
-//            List<WebElement> aElements = wait.until(ExpectedConditions.presenceOfAllElementsLocatedBy(
-//                    By.cssSelector("a.place_thumb.QX0J7")));
-//
-//            log.info("place_thumb QX0J7 클래스를 가진 a 태그 {}개 발견", aElements.size());
-//            System.out.println("place_thumb QX0J7 클래스를 가진 a 태그 " + aElements.size() + "개 발견");
+//            List<WebElement> aElements = webDriver.findElements(By.cssSelector("a.place_thumb.QX0J7"));
 //
 //            for (WebElement aElement : aElements) {
 //                // a 태그 내부의 img 태그 찾기
 //                List<WebElement> imgElements = aElement.findElements(By.tagName("img"));
-//                log.info("a 태그 내부 img 태그 {}개 발견", imgElements.size());
-//                System.out.println("a 태그 내부 img 태그 " + imgElements.size() + "개 발견");
 //
 //                for (WebElement img : imgElements) {
 //                    String src = img.getAttribute("src");
-//                    log.info("발견된 이미지 URL: {}", src);
-//                    System.out.println("발견된 이미지 URL: " + src);
-//
 //                    if (isValidImageUrl(src)) {
 //                        log.info("유효한 이미지 URL 발견: {}", src);
-//                        System.out.println("유효한 이미지 URL 발견: " + src);
 //                        return src;
-//                    } else {
-//                        System.out.println("유효하지 않은 이미지 URL: " + src);
 //                    }
 //                }
 //            }
-//        } catch (TimeoutException e) {
-//            log.info("place_thumb QX0J7 클래스를 가진 a 태그를 찾을 수 없음 (TimeoutException)");
-//            System.out.println("place_thumb QX0J7 클래스를 가진 a 태그를 찾을 수 없음 (TimeoutException)");
+//
 //        } catch (Exception e) {
 //            log.warn("place_thumb QX0J7 클래스 검색 중 오류: {}", e.getMessage());
-//            System.out.println("place_thumb QX0J7 클래스 검색 중 오류: " + e.getMessage());
-//            e.printStackTrace();
+//        } finally {
+//            // 메인 프레임으로 다시 전환
+//            try {
+//                webDriver.switchTo().defaultContent();
+//            } catch (Exception e) {
+//                log.warn("메인 프레임 전환 실패: {}", e.getMessage());
+//            }
 //        }
-//        System.out.println("findImageBySpecificATag null 반환");
 //        return null;
 //    }
-
-    private String findImageByClassName(String className) {
-        try {
-            WebDriverWait wait = new WebDriverWait(webDriver, Duration.ofSeconds(5));
-
-            // 일반적인 className으로 시도
-            List<WebElement> imageElements = webDriver.findElements(By.className(className));
-            for (WebElement img : imageElements) {
-                String src = img.getAttribute("src");
-                if (isValidImageUrl(src)) {
-                    return src;
-                }
-            }
-        } catch (TimeoutException e) {
-            log.debug("클래스명 '{}'로 이미지를 찾을 수 없음", className);
-        }
-        return null;
-    }
-
-    private String findImageByGenericSelector() {
-        try {
-            // 네이버 지도에서 자주 사용되는 이미지 셀렉터들
-            String[] selectors = {
-                    "a.place_thumb.QX0J7 img",  // 특정 클래스의 a 태그 내 img
-                    "a.place_thumb img",        // place_thumb 클래스의 a 태그 내 img
-                    "img[src*='pstatic.net']",
-                    "img[src*='naver.net']",
-                    ".place_thumb img",
-                    ".photo_area img",
-                    ".list_photo img"
-            };
-
-            for (String selector : selectors) {
-                List<WebElement> images = webDriver.findElements(By.cssSelector(selector));
-                log.debug("셀렉터 '{}' - {}개 이미지 발견", selector, images.size());
-
-                for (WebElement img : images) {
-                    String src = img.getAttribute("src");
-                    if (isValidImageUrl(src)) {
-                        log.info("유효한 이미지 URL 발견 (셀렉터: {}): {}", selector, src);
-                        return src;
-                    }
-                }
-            }
-        } catch (Exception e) {
-            log.debug("일반 셀렉터로 이미지 검색 실패: {}", e.getMessage());
-        }
-        return null;
-    }
-
-    private boolean isValidImageUrl(String url) {
-        if (url == null || url.trim().isEmpty()) {
-            return false;
-        }
-
-        return url.startsWith("http") &&
-                (url.contains(".jpg") || url.contains(".jpeg") || url.contains(".png") || url.contains(".gif")) &&
-                !url.contains("icon") &&
-                !url.contains("logo") &&
-                !url.contains("btn") &&
-                !url.contains("arrow");
-    }
-
-    @PreDestroy
-    public void cleanup() {
-        if (webDriver != null) {
-            webDriver.quit();
-        }
-    }
-}
+//
+////    private String findImageBySpecificATag() {
+////        System.out.println("findImageBySpecificATag 들어옴");
+////        try {
+////            WebDriverWait wait = new WebDriverWait(webDriver, Duration.ofSeconds(20));
+////
+////            // place_thumb QX0J7 클래스를 가진 a 태그 찾기
+////            List<WebElement> aElements = wait.until(ExpectedConditions.presenceOfAllElementsLocatedBy(
+////                    By.cssSelector("a.place_thumb.QX0J7")));
+////
+////            log.info("place_thumb QX0J7 클래스를 가진 a 태그 {}개 발견", aElements.size());
+////            System.out.println("place_thumb QX0J7 클래스를 가진 a 태그 " + aElements.size() + "개 발견");
+////
+////            for (WebElement aElement : aElements) {
+////                // a 태그 내부의 img 태그 찾기
+////                List<WebElement> imgElements = aElement.findElements(By.tagName("img"));
+////                log.info("a 태그 내부 img 태그 {}개 발견", imgElements.size());
+////                System.out.println("a 태그 내부 img 태그 " + imgElements.size() + "개 발견");
+////
+////                for (WebElement img : imgElements) {
+////                    String src = img.getAttribute("src");
+////                    log.info("발견된 이미지 URL: {}", src);
+////                    System.out.println("발견된 이미지 URL: " + src);
+////
+////                    if (isValidImageUrl(src)) {
+////                        log.info("유효한 이미지 URL 발견: {}", src);
+////                        System.out.println("유효한 이미지 URL 발견: " + src);
+////                        return src;
+////                    } else {
+////                        System.out.println("유효하지 않은 이미지 URL: " + src);
+////                    }
+////                }
+////            }
+////        } catch (TimeoutException e) {
+////            log.info("place_thumb QX0J7 클래스를 가진 a 태그를 찾을 수 없음 (TimeoutException)");
+////            System.out.println("place_thumb QX0J7 클래스를 가진 a 태그를 찾을 수 없음 (TimeoutException)");
+////        } catch (Exception e) {
+////            log.warn("place_thumb QX0J7 클래스 검색 중 오류: {}", e.getMessage());
+////            System.out.println("place_thumb QX0J7 클래스 검색 중 오류: " + e.getMessage());
+////            e.printStackTrace();
+////        }
+////        System.out.println("findImageBySpecificATag null 반환");
+////        return null;
+////    }
+//
+//    private String findImageByClassName(String className) {
+//        try {
+//            WebDriverWait wait = new WebDriverWait(webDriver, Duration.ofSeconds(5));
+//
+//            // 일반적인 className으로 시도
+//            List<WebElement> imageElements = webDriver.findElements(By.className(className));
+//            for (WebElement img : imageElements) {
+//                String src = img.getAttribute("src");
+//                if (isValidImageUrl(src)) {
+//                    return src;
+//                }
+//            }
+//        } catch (TimeoutException e) {
+//            log.debug("클래스명 '{}'로 이미지를 찾을 수 없음", className);
+//        }
+//        return null;
+//    }
+//
+//    private String findImageByGenericSelector() {
+//        try {
+//            // 네이버 지도에서 자주 사용되는 이미지 셀렉터들
+//            String[] selectors = {
+//                    "a.place_thumb.QX0J7 img",  // 특정 클래스의 a 태그 내 img
+//                    "a.place_thumb img",        // place_thumb 클래스의 a 태그 내 img
+//                    "img[src*='pstatic.net']",
+//                    "img[src*='naver.net']",
+//                    ".place_thumb img",
+//                    ".photo_area img",
+//                    ".list_photo img"
+//            };
+//
+//            for (String selector : selectors) {
+//                List<WebElement> images = webDriver.findElements(By.cssSelector(selector));
+//                log.debug("셀렉터 '{}' - {}개 이미지 발견", selector, images.size());
+//
+//                for (WebElement img : images) {
+//                    String src = img.getAttribute("src");
+//                    if (isValidImageUrl(src)) {
+//                        log.info("유효한 이미지 URL 발견 (셀렉터: {}): {}", selector, src);
+//                        return src;
+//                    }
+//                }
+//            }
+//        } catch (Exception e) {
+//            log.debug("일반 셀렉터로 이미지 검색 실패: {}", e.getMessage());
+//        }
+//        return null;
+//    }
+//
+//    private boolean isValidImageUrl(String url) {
+//        if (url == null || url.trim().isEmpty()) {
+//            return false;
+//        }
+//
+//        return url.startsWith("http") &&
+//                (url.contains(".jpg") || url.contains(".jpeg") || url.contains(".png") || url.contains(".gif")) &&
+//                !url.contains("icon") &&
+//                !url.contains("logo") &&
+//                !url.contains("btn") &&
+//                !url.contains("arrow");
+//    }
+//
+//    @PreDestroy
+//    public void cleanup() {
+//        if (webDriver != null) {
+//            webDriver.quit();
+//        }
+//    }
+//}

--- a/src/main/java/com/restspotfinder/domain/restarea/service/RestAreaService.java
+++ b/src/main/java/com/restspotfinder/domain/restarea/service/RestAreaService.java
@@ -1,11 +1,12 @@
 package com.restspotfinder.domain.restarea.service;
 
 import com.restspotfinder.domain.restarea.dto.RestAreaResponse;
+import com.restspotfinder.domain.restarea.dto.RestAreaDetailResponse;
 import java.util.List;
 
 
 public interface RestAreaService {
-    RestAreaResponse getOneById(long restAreaId);
+    RestAreaDetailResponse getDetailById(long restAreaId);
 
     List<RestAreaResponse> getRestAreasWithPointCounts(long routeI);
 }

--- a/src/main/java/com/restspotfinder/domain/restarea/service/impl/RestAreaServiceImpl.java
+++ b/src/main/java/com/restspotfinder/domain/restarea/service/impl/RestAreaServiceImpl.java
@@ -1,5 +1,7 @@
 package com.restspotfinder.domain.restarea.service.impl;
 
+import com.restspotfinder.domain.fuel.entity.FuelUpdateHistory;
+import com.restspotfinder.domain.fuel.error.FuelErrorCode;
 import com.restspotfinder.domain.interchange.service.InterchangeService;
 import com.restspotfinder.domain.restarea.collection.RestAreas;
 import com.restspotfinder.domain.restarea.entity.RestArea;
@@ -7,6 +9,7 @@ import com.restspotfinder.domain.restarea.repository.RestAreaRepository;
 import com.restspotfinder.domain.restarea.dto.RestAreaResponse;
 import com.restspotfinder.domain.restarea.dto.RestAreaDetailResponse;
 import com.restspotfinder.domain.restarea.service.RestAreaService;
+import com.restspotfinder.domain.fuel.repository.FuelUpdateHistoryRepository;
 import com.restspotfinder.domain.route.entity.Route;
 import com.restspotfinder.domain.route.repository.RouteRepository;
 import com.restspotfinder.domain.route.enums.Direction;
@@ -30,6 +33,7 @@ import java.util.stream.IntStream;
 public class RestAreaServiceImpl implements RestAreaService {
     private final RestAreaRepository restAreaRepository;
     private final RouteRepository routeRepository;
+    private final FuelUpdateHistoryRepository fuelUpdateHistoryRepository;
 
     private final InterchangeService interchangeService;
 
@@ -38,7 +42,10 @@ public class RestAreaServiceImpl implements RestAreaService {
         RestArea restArea = restAreaRepository.findByIdWithFuelStation(restAreaId)
                 .orElseThrow(() -> new BusinessException(RestAreaErrorCode.NOT_FOUND));
 
-        return RestAreaDetailResponse.from(restArea);
+        FuelUpdateHistory fuelUpdateHistory = fuelUpdateHistoryRepository.findFirstByIsSuccessTrueOrderByUpdateStartedAtDesc()
+                .orElseThrow(() -> new BusinessException(FuelErrorCode.NOT_FOUND));
+
+        return RestAreaDetailResponse.of(restArea, fuelUpdateHistory.getUpdateStartedAt());
     }
 
     @Override

--- a/src/main/java/com/restspotfinder/domain/restarea/service/impl/RestAreaServiceImpl.java
+++ b/src/main/java/com/restspotfinder/domain/restarea/service/impl/RestAreaServiceImpl.java
@@ -5,6 +5,7 @@ import com.restspotfinder.domain.restarea.collection.RestAreas;
 import com.restspotfinder.domain.restarea.entity.RestArea;
 import com.restspotfinder.domain.restarea.repository.RestAreaRepository;
 import com.restspotfinder.domain.restarea.dto.RestAreaResponse;
+import com.restspotfinder.domain.restarea.dto.RestAreaDetailResponse;
 import com.restspotfinder.domain.restarea.service.RestAreaService;
 import com.restspotfinder.domain.route.entity.Route;
 import com.restspotfinder.domain.route.repository.RouteRepository;
@@ -33,11 +34,11 @@ public class RestAreaServiceImpl implements RestAreaService {
     private final InterchangeService interchangeService;
 
     @Override
-    public RestAreaResponse getOneById(long restAreaId) {
-        RestArea restArea = restAreaRepository.findById(restAreaId)
+    public RestAreaDetailResponse getDetailById(long restAreaId) {
+        RestArea restArea = restAreaRepository.findByIdWithFuelStation(restAreaId)
                 .orElseThrow(() -> new BusinessException(RestAreaErrorCode.NOT_FOUND));
 
-        return RestAreaResponse.from(restArea);
+        return RestAreaDetailResponse.from(restArea);
     }
 
     @Override

--- a/src/main/java/com/restspotfinder/scheduler/FuelScheduler.java
+++ b/src/main/java/com/restspotfinder/scheduler/FuelScheduler.java
@@ -12,11 +12,8 @@ import org.springframework.stereotype.Component;
 public class FuelScheduler {
     private final FuelService fuelService;
 
-    // 매일 자정에 실행
     @Scheduled(cron = "0 0 9 * * *", zone = "Asia/Seoul")
-    public void updateFuelStationDaliy() {
-        log.info("⛽ 연료 정보 스케줄러 실행 시작");
+    public void updateFuelStationDaily() {
         fuelService.updateFuelStationsFromApi();
-        log.info("✅ 연료 정보 스케줄러 실행 완료");
     }
 }


### PR DESCRIPTION
## 💡 개요 (필수)

휴게소 상세 조회 API에 주유소 가격 정보 및 업데이트 이력 관리 기능을 추가

<br/>

## 📃 작업내용 (필수)

1. **FuelUpdateHistory 엔티티 추가**
   - 주유소 가격 업데이트 이력을 추적하기 위한 엔티티 생성
   - 업데이트 성공/실패 여부 및 타임스탬프 관리

2. **RestAreaDetailResponse DTO 생성**
   - 휘발유, 경유, LPG 가격 정보를 포함한 상세 응답 DTO 추가
   - 주유소 가격 업데이트 최신 날짜(lastFuelUpdateDate) 필드 추가

3. **FuelUpdateHistoryRepository 메서드 추가**
   - 가장 최근 성공한 주유소 가격 업데이트 이력 조회 메서드 구현

4. **RestAreaServiceImpl 업데이트**
   - 주유소 업데이트 이력과 함께 상세 정보 응답 생성 로직 추가
   - 기존 휴게소 정보에 주유소 가격 데이터 통합

<br/>

## 🔀 변경사항 (선택)

- **신규 추가**: FuelUpdateHistory 엔티티, RestAreaDetailResponse DTO
- **기능 개선**: 휴게소 상세 조회 API에 주유소 가격 정보 및 업데이트 날짜 추가
- **데이터 관리**: 주유소 가격 업데이트 이력 추적 시스템 구축
- **사용자 경험**: 클라이언트에서 주유소 가격 정보의 최신성 확인 가능

<br/>